### PR TITLE
Added .devcontainer folder with configuration for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/anaconda
+
+RUN conda install -n base -c conda-forge mamba
+
+COPY environment.yml* /tmp/conda-tmp/
+
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/mamba env create -f /tmp/conda-tmp/environment.yml; fi && rm -rf /tmp/conda-tmp

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,4 @@ FROM mcr.microsoft.com/devcontainers/anaconda
 
 RUN conda install -n base -c conda-forge mamba
 
-COPY environment.yml* /tmp/conda-tmp/
-
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/mamba env create -f /tmp/conda-tmp/environment.yml; fi && rm -rf /tmp/conda-tmp
+RUN umask 0002 && /opt/conda/bin/mamba env create -n intro-python-2 -c conda-forge python=3.11 jupyter ipykernal ipywidgets geopandas mapclassify contextily; fi && rm -rf /tmp/conda-tmp

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/miniconda
+{
+	"name": "Intro Python Geospatial - Day 1",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": []
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "conda init",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.defaultInterpreterPath": "/opt/conda/envs/intro-python-1"
+			},
+			"extensions": [
+				"ms-python.python",
+				"ms-toolsai.jupyter",
+				"GitHub.codespaces",
+				"ms-azuretools.vscode-docker",
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/miniconda
 {
-	"name": "Intro Python Geospatial - Day 1",
+	"name": "Intro Python Geospatial - Day 2",
 	"build": { 
 		"context": "..",
 		"dockerfile": "Dockerfile"
@@ -20,7 +20,7 @@
 	"customizations": {
 		"vscode": {
 			"settings": {
-				"python.defaultInterpreterPath": "/opt/conda/envs/intro-python-1"
+				"python.defaultInterpreterPath": "/opt/conda/envs/intro-python-2"
 			},
 			"extensions": [
 				"ms-python.python",


### PR DESCRIPTION
Added .devcontainer folder with configuration for Codespaces

See the "Teaching data science" section in https://techcommunity.microsoft.com/blog/educatordeveloperblog/teaching-python-with-github-codespaces/4419687

Uses the following image: https://github.com/devcontainers/images/tree/main/src/anaconda

devcontainer.json has been updated for Dev Container Name and python.defaultInterpreterPath.

 **Setup currently fails due to environment.yml incompatibility with base image OS**